### PR TITLE
Add Spanish internationalization with language switcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "framer-motion": "^12.18.1",
+    "i18next": "^25.2.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-i18next": "^15.5.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       framer-motion:
         specifier: ^12.18.1
         version: 12.18.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      i18next:
+        specifier: ^25.2.1
+        version: 25.2.1
       react:
         specifier: ^19.1.0
         version: 19.1.0
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-i18next:
+        specifier: ^15.5.3
+        version: 15.5.3(i18next@25.2.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.25.0
@@ -137,6 +143,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -1027,6 +1037,17 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  i18next@25.2.1:
+    resolution: {integrity: sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1446,6 +1467,22 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-i18next@15.5.3:
+    resolution: {integrity: sha512-ypYmOKOnjqPEJZO4m1BI0kS8kWqkBNsKYyhVUfij0gvjy9xJNoG/VcGkxq5dRlVwzmrmY1BQMAmpbbUBLwC4Kw==}
+    peerDependencies:
+      i18next: '>= 23.2.3'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1718,6 +1755,10 @@ packages:
       yaml:
         optional: true
 
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1858,6 +1899,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/runtime@7.27.6': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -2813,6 +2856,14 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
+  i18next@25.2.1:
+    dependencies:
+      '@babel/runtime': 7.27.6
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -3210,6 +3261,15 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-i18next@15.5.3(i18next@25.2.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      html-parse-stringify: 3.0.1
+      i18next: 25.2.1
+      react: 19.1.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
@@ -3576,6 +3636,8 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       yaml: 2.8.0
+
+  void-elements@3.1.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/components/LandingPageReseller.jsx
+++ b/src/components/LandingPageReseller.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { motion as Motion, AnimatePresence } from 'framer-motion';
+import LanguageSwitcher from './LanguageSwitcher';
 
 /* ---------------------------------------------------------------------
   LOGO ‐ Placeholder word‑mark
@@ -18,54 +20,6 @@ const Logo = () => (
 /* ---------------------------------------------------------------------
   FAQ  – minimal, collapsible accordion so users aren’t overwhelmed
 --------------------------------------------------------------------- */
-const faqItems = [
-  {
-    q: 'What types of auto parts do you specialise in?',
-    a: 'Our MVP focuses on high-demand body panels and lighting (headlamps, tail-lamps, bumpers, fenders) from trusted Taiwanese OEM-approved factories.'
-  },
-  { q: 'Are your parts OEM or aftermarket?',
-    a: 'All items meet or exceed SAE/DOT standards and are produced in ISO-certified facilities, giving you OEM-level fit and finish at aftermarket pricing.'
-  },
-  { q: 'How long does delivery to the US take?',
-    a: 'Our strategic Dubai hub ensures very fast shipping to your door without customs headaches.'
-  },
-  { q: 'Is there a minimum order quantity (MOQ)?',
-    a: 'Yes. To secure factory-direct pricing we currently operate on full-container or skid-lot quantities (≈ USD 40k). Mixed-model containers are allowed.'
-  },
-  { q: 'Can I mix different models/part numbers in one container?',
-    a: 'Absolutely. We’ll work with you to build a mixed SKU manifest so you can stock a sensible spread of high-turn items.'
-  },
-  { q: 'How do payments work?',
-    a: 'Customer funds are deposited into escrow. Once your shipment is confirmed on board, funds are released to us and production/dispatch begins.'
-  },
-  { q: 'Do you offer credit terms?',
-    a: 'For the MVP we operate on escrow/pre-paid terms. Credit programs will roll out after consistent order history (≈3 containers).'
-  },
-  { q: 'What warranty do you provide?',
-    a: 'We back every part with a standard 12-month warranty against manufacturing defects. Extended plans available for volume clients.'
-  },
-  { q: 'Are returns accepted?',
-    a: 'Yes—if a part arrives damaged or does not fit the specified vehicle, we arrange replacement or credit. Full return guidelines are in the supply agreement.'
-  },
-  { q: 'Which US ports do you ship to?',
-    a: 'Los Angeles, Long Beach, Houston, Newark (NY/NJ) and Savannah. Inland drayage to your facility can be quoted on request.'
-  },
-  { q: 'Can I brand the packaging with my logo?',
-    a: 'Private-label options are available for repeat clients. MOQ for custom prints is typically 300 units per part number.'
-  },
-  { q: 'How are duties and customs handled?',
-    a: 'Our forwarder files all ISF and entry paperwork. Duties (2.5 % ad valorem on most parts) are billed at cost; we’ll guide you through every step.'
-  },
-  { q: 'Do you provide fitment data or catalog feeds?',
-    a: 'Yes—CSV/XML fitment tables (year/make/model) and hi-res imagery are included so you can update your webshop instantly.'
-  },
-  { q: 'Is drop-shipping to my customers possible?',
-    a: 'Large-parcel drop-ship from our US 3PL is slated for phase 2. Join the wait-list and we’ll notify you when live.'
-  },
-  { q: 'How do I get started?',
-    a: 'Click “Book a Quick Call” to schedule a 15-minute discovery session. We’ll review your part list, map savings, and design your first container load.'
-  }
-];
 
 const FAQItem = ({ q, a, idx, isOpen, onToggle }) => (
   <div className="border-b border-gray-200">
@@ -102,17 +56,19 @@ const FAQItem = ({ q, a, idx, isOpen, onToggle }) => (
 );
 
 const FAQSection = () => {
+  const { t } = useTranslation();
+  const items = t('faq.items', { returnObjects: true });
   const [openIdx, setOpenIdx] = useState(null);
   const toggle = (idx) => setOpenIdx(idx === openIdx ? null : idx);
 
   return (
     <section className="bg-white py-12 px-6" id="faq">
       <div className="container mx-auto max-w-4xl">
-        <h2 className="text-2xl font-bold mb-8 text-center">Frequently Asked Questions</h2>
+        <h2 className="text-2xl font-bold mb-8 text-center">{t('faq.title')}</h2>
         <div
           className="divide-y divide-gray-200 max-h-96 overflow-y-auto overflow-x-hidden rounded-md faq-scroll"
         >
-          {faqItems.map((item, idx) => (
+          {items.map((item, idx) => (
             <FAQItem
               key={idx}
               idx={idx}
@@ -131,6 +87,7 @@ const FAQSection = () => {
   LANDING PAGE COMPONENT
 --------------------------------------------------------------------- */
 function LandingPageReseller() {
+  const { t } = useTranslation();
   const calendlyRef = useRef(null);
 
   useEffect(() => {
@@ -169,14 +126,17 @@ function LandingPageReseller() {
     <div className="font-sans text-gray-800 scroll-smooth">
       {/* Hero */}
       <header>
-        <section className="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white py-16 px-6">
+        <section className="relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white py-16 px-6">
+          <div className="absolute top-4 right-4">
+            <LanguageSwitcher />
+          </div>
           <div className="container mx-auto text-center flex flex-col items-center">
             <Logo />
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">Wholesale OEM Auto Parts Direct from Factory</h1>
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">{t('hero.title')}</h1>
             <p className="text-xl mb-8 max-w-2xl mx-auto">
-              Factory-direct pricing, OEM quality and fast shipping from Dubai.
+              {t('hero.tagline1')}
               <br className="hidden md:block" />
-              AutoLink Global gives wholesale resellers a competitive edge.
+              {t('hero.tagline2')}
             </p>
             <div className="flex flex-col sm:flex-row justify-center gap-4">
               <a
@@ -185,13 +145,13 @@ function LandingPageReseller() {
                 rel="noopener noreferrer"
                 className="bg-red-600 text-white px-5 py-3 rounded-md text-lg font-semibold hover:bg-red-700 transition"
               >
-                Download Catalog
+                {t('hero.download')}
               </a>
               <a
                 href="mailto:sales@autolinkglobal.com?subject=Parts%20Inquiry"
                 className="bg-white text-gray-900 px-5 py-3 rounded-md text-lg font-semibold hover:bg-gray-100 transition"
               >
-                Contact Sales
+                {t('hero.contact')}
               </a>
             </div>
           </div>
@@ -202,19 +162,19 @@ function LandingPageReseller() {
       {/* Why Choose Us */}
         <section className="py-12 bg-white text-gray-900">
           <div className="container mx-auto px-6">
-            <h2 className="text-2xl font-bold mb-8 text-center">Why Choose AutoLink Global for Auto Parts?</h2>
+            <h2 className="text-2xl font-bold mb-8 text-center">{t('choose.title')}</h2>
             <div className="md:flex md:space-x-8 space-y-8 md:space-y-0">
               <div className="flex-1 bg-gray-100 p-6 rounded-xl shadow-sm">
-                <h3 className="text-xl font-semibold mb-2">OEM-Level Quality</h3>
-                <p>All parts meet or exceed SAE/DOT standards and come with a solid warranty.</p>
+                <h3 className="text-xl font-semibold mb-2">{t('choose.oem.title')}</h3>
+                <p>{t('choose.oem.desc')}</p>
               </div>
               <div className="flex-1 bg-gray-100 p-6 rounded-xl shadow-sm">
-                <h3 className="text-xl font-semibold mb-2">Direct-from-Factory Pricing</h3>
-                <p>Skip the middle-man. Our Taiwan partnerships let you save 10-15% on average.</p>
+                <h3 className="text-xl font-semibold mb-2">{t('choose.price.title')}</h3>
+                <p>{t('choose.price.desc')}</p>
               </div>
               <div className="flex-1 bg-gray-100 p-6 rounded-xl shadow-sm">
-                <h3 className="text-xl font-semibold mb-2">Fast Delivery</h3>
-                <p>Our strategic Dubai hub ensures quick shipping to the US without customs headaches.</p>
+                <h3 className="text-xl font-semibold mb-2">{t('choose.delivery.title')}</h3>
+                <p>{t('choose.delivery.desc')}</p>
               </div>
             </div>
           </div>
@@ -222,15 +182,15 @@ function LandingPageReseller() {
 
         {/* CTA linking to booking section */}
         <section className="py-16 bg-gray-900 text-center text-white px-6">
-          <h2 className="text-3xl font-bold mb-4">Ready to turbo-charge profits?</h2>
+          <h2 className="text-3xl font-bold mb-4">{t('cta.title')}</h2>
           <p className="text-lg mb-8 max-w-xl mx-auto">
-            Join dozens of US body shops already saving on premium parts.
+            {t('cta.subtitle')}
           </p>
           <a
             href="#book-call"
             className="inline-block bg-red-600 text-white px-7 py-4 rounded-md text-lg font-semibold hover:bg-red-700 transition"
           >
-            Book a Quick Call
+            {t('cta.button')}
           </a>
         </section>
 
@@ -239,12 +199,12 @@ function LandingPageReseller() {
 
         {/* Booking section with Calendly */}
         <section id="book-call" className="py-16 bg-gray-900 text-center text-white px-6">
-          <h2 className="text-4xl font-extrabold text-red-500 mb-4">Book Your Free Discovery Call</h2>
+          <h2 className="text-4xl font-extrabold text-red-500 mb-4">{t('booking.title')}</h2>
           <p className="text-lg mb-4 max-w-xl mx-auto">
-            Spend 15 minutes with our team to learn how you can save big on premium parts.
+            {t('booking.subtitle1')}
           </p>
           <p className="mb-8 max-w-xl mx-auto">
-            Choose a time that works for you—we’ll review your parts list and map out exact savings with AutoLink Global.
+            {t('booking.subtitle2')}
           </p>
           <div className="flex justify-center">
             <div
@@ -256,7 +216,7 @@ function LandingPageReseller() {
       </main>
       {/* Footer */}
       <footer className="bg-gray-900 text-gray-400 text-sm py-4 text-center">
-        © 2025 AutoLink Global. All rights reserved.
+        {t('footer.text')}
       </footer>
     </div>
   );

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+
+function LanguageSwitcher() {
+  const { i18n } = useTranslation();
+  const changeLanguage = (e) => {
+    i18n.changeLanguage(e.target.value);
+    document.documentElement.lang = e.target.value;
+  };
+
+  return (
+    <select
+      value={i18n.language}
+      onChange={changeLanguage}
+      className="bg-gray-100 text-gray-800 px-2 py-1 rounded-md text-sm"
+    >
+      <option value="en">EN</option>
+      <option value="es">ES</option>
+    </select>
+  );
+}
+
+export default LanguageSwitcher;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,27 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './locales/en/translation.json';
+import es from './locales/es/translation.json';
+
+const resources = {
+  en: { translation: en },
+  es: { translation: es },
+};
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+i18n.on('languageChanged', (lng) => {
+  document.documentElement.lang = lng;
+});
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,102 @@
+{
+  "hero": {
+    "title": "Wholesale OEM Auto Parts Direct from Factory",
+    "tagline1": "Factory-direct pricing, OEM quality and fast shipping from Dubai.",
+    "tagline2": "AutoLink Global gives wholesale resellers a competitive edge.",
+    "download": "Download Catalog",
+    "contact": "Contact Sales"
+  },
+  "choose": {
+    "title": "Why Choose AutoLink Global for Auto Parts?",
+    "oem": {
+      "title": "OEM-Level Quality",
+      "desc": "All parts meet or exceed SAE/DOT standards and come with a solid warranty."
+    },
+    "price": {
+      "title": "Direct-from-Factory Pricing",
+      "desc": "Skip the middle-man. Our Taiwan partnerships let you save 10-15% on average."
+    },
+    "delivery": {
+      "title": "Fast Delivery",
+      "desc": "Our strategic Dubai hub ensures quick shipping to the US without customs headaches."
+    }
+  },
+  "cta": {
+    "title": "Ready to turbo-charge profits?",
+    "subtitle": "Join dozens of US body shops already saving on premium parts.",
+    "button": "Book a Quick Call"
+  },
+  "faq": {
+    "title": "Frequently Asked Questions",
+    "items": [
+      {
+        "q": "What types of auto parts do you specialise in?",
+        "a": "Our MVP focuses on high-demand body panels and lighting (headlamps, tail-lamps, bumpers, fenders) from trusted Taiwanese OEM-approved factories."
+      },
+      {
+        "q": "Are your parts OEM or aftermarket?",
+        "a": "All items meet or exceed SAE/DOT standards and are produced in ISO-certified facilities, giving you OEM-level fit and finish at aftermarket pricing."
+      },
+      {
+        "q": "How long does delivery to the US take?",
+        "a": "Our strategic Dubai hub ensures very fast shipping to your door without customs headaches."
+      },
+      {
+        "q": "Is there a minimum order quantity (MOQ)?",
+        "a": "Yes. To secure factory-direct pricing we currently operate on full-container or skid-lot quantities (≈ USD 40k). Mixed-model containers are allowed."
+      },
+      {
+        "q": "Can I mix different models/part numbers in one container?",
+        "a": "Absolutely. We’ll work with you to build a mixed SKU manifest so you can stock a sensible spread of high-turn items."
+      },
+      {
+        "q": "How do payments work?",
+        "a": "Customer funds are deposited into escrow. Once your shipment is confirmed on board, funds are released to us and production/dispatch begins."
+      },
+      {
+        "q": "Do you offer credit terms?",
+        "a": "For the MVP we operate on escrow/pre-paid terms. Credit programs will roll out after consistent order history (≈3 containers)."
+      },
+      {
+        "q": "What warranty do you provide?",
+        "a": "We back every part with a standard 12-month warranty against manufacturing defects. Extended plans available for volume clients."
+      },
+      {
+        "q": "Are returns accepted?",
+        "a": "Yes—if a part arrives damaged or does not fit the specified vehicle, we arrange replacement or credit. Full return guidelines are in the supply agreement."
+      },
+      {
+        "q": "Which US ports do you ship to?",
+        "a": "Los Angeles, Long Beach, Houston, Newark (NY/NJ) and Savannah. Inland drayage to your facility can be quoted on request."
+      },
+      {
+        "q": "Can I brand the packaging with my logo?",
+        "a": "Private-label options are available for repeat clients. MOQ for custom prints is typically 300 units per part number."
+      },
+      {
+        "q": "How are duties and customs handled?",
+        "a": "Our forwarder files all ISF and entry paperwork. Duties (2.5 % ad valorem on most parts) are billed at cost; we’ll guide you through every step."
+      },
+      {
+        "q": "Do you provide fitment data or catalog feeds?",
+        "a": "Yes—CSV/XML fitment tables (year/make/model) and hi-res imagery are included so you can update your webshop instantly."
+      },
+      {
+        "q": "Is drop-shipping to my customers possible?",
+        "a": "Large-parcel drop-ship from our US 3PL is slated for phase 2. Join the wait-list and we’ll notify you when live."
+      },
+      {
+        "q": "How do I get started?",
+        "a": "Click “Book a Quick Call” to schedule a 15-minute discovery session. We’ll review your part list, map savings, and design your first container load."
+      }
+    ]
+  },
+  "booking": {
+    "title": "Book Your Free Discovery Call",
+    "subtitle1": "Spend 15 minutes with our team to learn how you can save big on premium parts.",
+    "subtitle2": "Choose a time that works for you—we’ll review your parts list and map out exact savings with AutoLink Global."
+  },
+  "footer": {
+    "text": "© 2025 AutoLink Global. All rights reserved."
+  }
+}

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,0 +1,102 @@
+{
+  "hero": {
+    "title": "Piezas de automóvil OEM al por mayor directamente de fábrica",
+    "tagline1": "Precios directos de fábrica, calidad OEM y envíos rápidos desde Dubái.",
+    "tagline2": "AutoLink Global brinda a los distribuidores mayoristas una ventaja competitiva.",
+    "download": "Descargar Catálogo",
+    "contact": "Contactar Ventas"
+  },
+  "choose": {
+    "title": "¿Por qué elegir AutoLink Global para repuestos?",
+    "oem": {
+      "title": "Calidad de nivel OEM",
+      "desc": "Todas las piezas cumplen o superan las normas SAE/DOT y cuentan con una sólida garantía."
+    },
+    "price": {
+      "title": "Precios directos de fábrica",
+      "desc": "Elimine intermediarios. Nuestras alianzas en Taiwán le permiten ahorrar entre un 10 y un 15 % en promedio."
+    },
+    "delivery": {
+      "title": "Entrega Rápida",
+      "desc": "Nuestro centro estratégico en Dubái garantiza envíos rápidos a EE. UU. sin complicaciones aduaneras."
+    }
+  },
+  "cta": {
+    "title": "¿Listo para impulsar sus ganancias?",
+    "subtitle": "Únase a decenas de talleres estadounidenses que ya ahorran en piezas de primera.",
+    "button": "Reservar una Llamada Rápida"
+  },
+  "faq": {
+    "title": "Preguntas Frecuentes",
+    "items": [
+      {
+        "q": "¿En qué tipos de repuestos automotrices están especializados?",
+        "a": "Nuestro MVP se centra en paneles de carrocería y sistemas de iluminación de alta demanda (faros, luces traseras, parachoques, guardabarros) de fábricas taiwanesas de confianza aprobadas por OEM."
+      },
+      {
+        "q": "¿Sus piezas son OEM o aftermarket?",
+        "a": "Todos los artículos cumplen o superan las normas SAE/DOT y se producen en instalaciones certificadas ISO, lo que le brinda ajuste y acabado de nivel OEM a precio de aftermarket."
+      },
+      {
+        "q": "¿Cuánto tarda el envío a Estados Unidos?",
+        "a": "Nuestro centro estratégico en Dubái asegura envíos muy rápidos a su puerta sin problemas de aduanas."
+      },
+      {
+        "q": "¿Existe una cantidad mínima de pedido (MOQ)?",
+        "a": "Sí. Para garantizar precios directos de fábrica actualmente operamos con contenedores completos o lotes por skid (≈ USD 40k). Se permiten contenedores con modelos mixtos."
+      },
+      {
+        "q": "¿Puedo mezclar distintos modelos/números de parte en un mismo contenedor?",
+        "a": "Por supuesto. Trabajaremos con usted para elaborar un manifiesto de SKU mezcladas para que pueda tener un inventario equilibrado de artículos de alta rotación."
+      },
+      {
+        "q": "¿Cómo funcionan los pagos?",
+        "a": "Los fondos del cliente se depositan en una cuenta escrow. Una vez que su envío está confirmado a bordo, los fondos se liberan y comienza la producción/despacho."
+      },
+      {
+        "q": "¿Ofrecen términos de crédito?",
+        "a": "Para el MVP trabajamos con términos en escrow/prepago. Los programas de crédito se lanzarán tras un historial de pedidos consistente (≈3 contenedores)."
+      },
+      {
+        "q": "¿Qué garantía ofrecen?",
+        "a": "Respaldamos cada pieza con una garantía estándar de 12 meses contra defectos de fabricación. Planes extendidos disponibles para clientes con volumen."
+      },
+      {
+        "q": "¿Aceptan devoluciones?",
+        "a": "Sí. Si una pieza llega dañada o no encaja en el vehículo especificado, organizamos el reemplazo o el crédito. Las pautas completas de devolución están en el acuerdo de suministro."
+      },
+      {
+        "q": "¿A qué puertos de EE. UU. envían?",
+        "a": "Los Ángeles, Long Beach, Houston, Newark (NY/NJ) y Savannah. El transporte interior a su instalación puede cotizarse a petición."
+      },
+      {
+        "q": "¿Puedo personalizar el embalaje con mi logo?",
+        "a": "Las opciones de marca propia están disponibles para clientes recurrentes. El MOQ para impresiones personalizadas suele ser de 300 unidades por número de parte."
+      },
+      {
+        "q": "¿Cómo se gestionan los aranceles y la aduana?",
+        "a": "Nuestro agente se encarga de presentar toda la documentación ISF y de entrada. Los aranceles (2.5 % ad valorem en la mayoría de las piezas) se facturan al costo; le guiaremos en cada paso."
+      },
+      {
+        "q": "¿Proporcionan datos de compatibilidad o feeds de catálogo?",
+        "a": "Sí. Se incluyen tablas de compatibilidad CSV/XML (año, marca, modelo) e imágenes de alta resolución para que pueda actualizar su tienda en línea al instante."
+      },
+      {
+        "q": "¿Es posible el envío directo a mis clientes?",
+        "a": "El envío directo de paquetes voluminosos desde nuestro 3PL en EE. UU. está previsto para la fase 2. Únase a la lista de espera y le avisaremos cuando esté disponible."
+      },
+      {
+        "q": "¿Cómo empiezo?",
+        "a": "Haga clic en «Reservar una Llamada Rápida» para programar una sesión de descubrimiento de 15 minutos. Revisaremos su lista de piezas, mapearemos los ahorros y diseñaremos su primer contenedor."
+      }
+    ]
+  },
+  "booking": {
+    "title": "Reserve su Llamada de Descubrimiento Gratis",
+    "subtitle1": "Dedique 15 minutos con nuestro equipo para descubrir cómo puede ahorrar a lo grande en piezas de primera.",
+    "subtitle2": "Elija la hora que le sea conveniente; revisaremos su lista de piezas y calcularemos el ahorro exacto con AutoLink Global."
+  },
+  "footer": {
+    "text": "© 2025 AutoLink Global. Todos los derechos reservados."
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './i18n'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <Suspense fallback={null}>
+      <App />
+    </Suspense>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- install `i18next` and `react-i18next`
- configure i18n and provide English & Spanish translations
- add language switcher component
- internationalize `LandingPageReseller` component

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_685971b6fd3c8325af808baf6b4101b2