### PR TITLE
Simpler light theme and language routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 
 A simple GitHub Actions workflow installs dependencies and verifies the build on every push.
 
+## Theming
+
+Primary colors are defined as CSS variables in `src/index.css` and exposed to Tailwind as `text-primary-*` and `bg-primary-*` utility classes. Update the `--color-primary-*` values to quickly change the site's color scheme.
+
 ## File structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "i18next": "^25.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-i18next": "^15.5.3"
+    "react-i18next": "^15.5.3",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-i18next:
         specifier: ^15.5.3
         version: 15.5.3(i18next@25.2.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-router-dom:
+        specifier: ^6.23.0
+        version: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.25.0
@@ -409,6 +412,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.11':
     resolution: {integrity: sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==}
@@ -1490,6 +1497,19 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@6.30.1:
+    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -2101,6 +2121,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.11': {}
 
@@ -3273,6 +3295,18 @@ snapshots:
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router: 6.30.1(react@19.1.0)
+
+  react-router@6.30.1(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 19.1.0
 
   react@19.1.0: {}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,24 @@
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import LandingPageReseller from './components/LandingPageReseller'
+import i18n from './i18n'
+
+function Page() {
+  const { lang } = useParams()
+  if (i18n.language !== lang) {
+    i18n.changeLanguage(lang)
+  }
+  return <LandingPageReseller />
+}
 
 function App() {
-  return <LandingPageReseller />
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Navigate to="/en" replace />} />
+        <Route path="/:lang" element={<Page />} />
+      </Routes>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/src/components/LandingPageReseller.jsx
+++ b/src/components/LandingPageReseller.jsx
@@ -13,7 +13,7 @@ import LanguageSwitcher from './LanguageSwitcher';
 */
 const Logo = () => (
   <div className="select-none text-3xl md:text-4xl font-extrabold leading-none tracking-wide mb-8">
-    AutoLink<span className="text-red-600">Global</span>
+    AutoLink<span className="text-primary-600">Global</span>
   </div>
 );
 
@@ -27,11 +27,11 @@ const FAQItem = ({ q, a, idx, isOpen, onToggle }) => (
       onClick={() => onToggle(idx)}
       className="w-full flex justify-between items-center py-4 text-left focus:outline-none group"
     >
-      <span className="font-medium text-gray-800 group-hover:text-red-600 transition">
+      <span className="font-medium text-gray-800 group-hover:text-primary-600 transition">
         {q}
       </span>
       <Motion.span
-        className="text-red-600 transform"
+        className="text-primary-600 transform"
         animate={{ rotate: isOpen ? 45 : 0 }}
         transition={{ duration: 0.2 }}
       >
@@ -94,7 +94,7 @@ function LandingPageReseller() {
     const initCalendly = () => {
       if (window.Calendly && calendlyRef.current) {
         window.Calendly.initInlineWidget({
-          url: 'https://calendly.com/sampogosyan1995/30min?text_color=dc2626&primary_color=151d2b',
+          url: 'https://calendly.com/sampogosyan1995/30min?text_color=2563eb&primary_color=151d2b',
           parentElement: calendlyRef.current,
         });
       }
@@ -126,7 +126,7 @@ function LandingPageReseller() {
     <div className="font-sans text-gray-800 scroll-smooth">
       {/* Hero */}
       <header>
-        <section className="relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white py-16 px-6">
+        <section className="relative bg-gradient-to-br from-white via-blue-50 to-white text-gray-900 py-16 px-6">
           <div className="absolute top-4 right-4">
             <LanguageSwitcher />
           </div>
@@ -143,7 +143,7 @@ function LandingPageReseller() {
                 href="/catalog.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-red-600 text-white px-5 py-3 rounded-md text-lg font-semibold hover:bg-red-700 transition"
+                className="bg-primary-600 text-white px-5 py-3 rounded-md text-lg font-semibold hover:bg-primary-700 transition"
               >
                 {t('hero.download')}
               </a>
@@ -181,14 +181,14 @@ function LandingPageReseller() {
         </section>
 
         {/* CTA linking to booking section */}
-        <section className="py-16 bg-gray-900 text-center text-white px-6">
+        <section className="py-16 bg-blue-50 text-center text-gray-900 px-6">
           <h2 className="text-3xl font-bold mb-4">{t('cta.title')}</h2>
           <p className="text-lg mb-8 max-w-xl mx-auto">
             {t('cta.subtitle')}
           </p>
           <a
             href="#book-call"
-            className="inline-block bg-red-600 text-white px-7 py-4 rounded-md text-lg font-semibold hover:bg-red-700 transition"
+            className="inline-block bg-primary-600 text-white px-7 py-4 rounded-md text-lg font-semibold hover:bg-primary-700 transition"
           >
             {t('cta.button')}
           </a>
@@ -198,8 +198,8 @@ function LandingPageReseller() {
         <FAQSection />
 
         {/* Booking section with Calendly */}
-        <section id="book-call" className="py-16 bg-gray-900 text-center text-white px-6">
-          <h2 className="text-4xl font-extrabold text-red-500 mb-4">{t('booking.title')}</h2>
+        <section id="book-call" className="py-16 bg-gray-50 text-center text-gray-900 px-6">
+          <h2 className="text-4xl font-extrabold text-primary-500 mb-4">{t('booking.title')}</h2>
           <p className="text-lg mb-4 max-w-xl mx-auto">
             {t('booking.subtitle1')}
           </p>
@@ -215,7 +215,7 @@ function LandingPageReseller() {
         </section>
       </main>
       {/* Footer */}
-      <footer className="bg-gray-900 text-gray-400 text-sm py-4 text-center">
+      <footer className="bg-gray-100 text-gray-600 text-sm py-4 text-center">
         {t('footer.text')}
       </footer>
     </div>

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,21 +1,34 @@
 import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
 
 function LanguageSwitcher() {
   const { i18n } = useTranslation();
-  const changeLanguage = (e) => {
-    i18n.changeLanguage(e.target.value);
-    document.documentElement.lang = e.target.value;
+  const navigate = useNavigate();
+  const { lang } = useParams();
+
+  const setLang = (lng) => {
+    if (lng !== lang) {
+      i18n.changeLanguage(lng);
+      navigate(`/${lng}`);
+    }
   };
 
   return (
-    <select
-      value={i18n.language}
-      onChange={changeLanguage}
-      className="bg-gray-100 text-gray-800 px-2 py-1 rounded-md text-sm"
-    >
-      <option value="en">EN</option>
-      <option value="es">ES</option>
-    </select>
+    <div className="flex border rounded-full overflow-hidden bg-white text-gray-800 text-sm">
+      {['en', 'es'].map((lng) => (
+        <button
+          key={lng}
+          type="button"
+          onClick={() => setLang(lng)}
+          className={`px-3 py-1 focus:outline-none transition-colors ${
+            lang === lng ? 'bg-primary-600 text-white' : 'bg-white text-gray-800'
+          }`}
+          aria-pressed={lang === lng}
+        >
+          {lng.toUpperCase()}
+        </button>
+      ))}
+    </div>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+}
+
 /* Custom scrollbar styling for the FAQ section */
 .faq-scroll {
   scrollbar-width: thin;
-  scrollbar-color: #dc2626 #f3f4f6;
+  scrollbar-color: var(--color-primary-600) #f3f4f6;
   padding-right: 16px; /* Add padding to make space for the scrollbar */
   box-sizing: content-box; /* Ensure padding doesn't affect the width */
 }
@@ -20,12 +26,12 @@
 }
 
 .faq-scroll::-webkit-scrollbar-thumb {
-  background-color: #dc2626;
+  background-color: var(--color-primary-600);
   border-radius: 4px;
 }
 
 .faq-scroll::-webkit-scrollbar-thumb:hover {
-  background-color: #b91c1c;
+  background-color: var(--color-primary-700);
 }
 
 .faq-scroll::-webkit-scrollbar {
@@ -34,7 +40,7 @@
 }
 
 .faq-scroll::-webkit-scrollbar-thumb {
-  background-color: #dc2626;
+  background-color: var(--color-primary-600);
   border-radius: 4px;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,13 @@
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'primary-500': 'var(--color-primary-500)',
+        'primary-600': 'var(--color-primary-600)',
+        'primary-700': 'var(--color-primary-700)',
+      },
+    },
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## Summary
- lighten dark sections of the landing page
- redesign LanguageSwitcher into toggle buttons
- add React Router and language-based routes

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_685987a130888325b14e1029711a7d0c