### PR TITLE
Add two alternate landing page versions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import LandingPageReseller from './components/LandingPageReseller'
+import LandingPageVersion1 from './components/LandingPageVersion1'
+import LandingPageVersion2 from './components/LandingPageVersion2'
 import i18n from './i18n'
 
 function Page() {
@@ -15,6 +17,8 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Navigate to="/en" replace />} />
+        <Route path="/version1" element={<LandingPageVersion1 />} />
+        <Route path="/version2" element={<LandingPageVersion2 />} />
         <Route path="/:lang" element={<Page />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/LandingPageVersion1.jsx
+++ b/src/components/LandingPageVersion1.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+function LandingPageVersion1() {
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100 font-mono">
+      <header className="py-20 text-center">
+        <h1 className="text-5xl font-bold mb-4">Affordable Auto Parts</h1>
+        <p className="text-xl mb-8">Direct from our warehouses to your door.</p>
+        <a
+          href="mailto:sales@autolinkglobal.com"
+          className="bg-blue-600 hover:bg-blue-500 text-white px-6 py-3 rounded"
+        >
+          Contact Us
+        </a>
+      </header>
+
+      <main className="px-6 space-y-16">
+        <section className="max-w-3xl mx-auto">
+          <h2 className="text-3xl font-semibold mb-4">Why Choose Us</h2>
+          <ul className="space-y-2 list-disc pl-5">
+            <li>Factory direct prices</li>
+            <li>Fast worldwide shipping</li>
+            <li>Warranty on all parts</li>
+          </ul>
+        </section>
+
+        <section className="bg-gray-800 p-8 rounded-lg text-center">
+          <h2 className="text-3xl font-semibold mb-4">Ready to Save?</h2>
+          <p className="mb-6">Join hundreds of shops benefiting from our low pricing.</p>
+          <a
+            href="#start"
+            className="bg-blue-600 hover:bg-blue-500 text-white px-6 py-3 rounded"
+          >
+            Start Now
+          </a>
+        </section>
+
+        <section id="start" className="max-w-3xl mx-auto">
+          <h2 className="text-3xl font-semibold mb-4">Get Started</h2>
+          <p className="mb-6">Send us your parts list and we will quote you today.</p>
+          <a
+            href="mailto:sales@autolinkglobal.com"
+            className="bg-blue-600 hover:bg-blue-500 text-white px-6 py-3 rounded"
+          >
+            Email Us
+          </a>
+        </section>
+      </main>
+
+      <footer className="py-8 text-center text-sm text-gray-400">
+        © 2025 AutoLink Global
+      </footer>
+    </div>
+  )
+}
+
+export default LandingPageVersion1

--- a/src/components/LandingPageVersion2.jsx
+++ b/src/components/LandingPageVersion2.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+function LandingPageVersion2() {
+  return (
+    <div className="min-h-screen bg-gradient-to-r from-yellow-50 via-red-50 to-purple-50 text-gray-900 font-serif">
+      <header className="py-24 text-center">
+        <h1 className="text-6xl font-extrabold mb-6 tracking-tight">Premium Parts Delivered</h1>
+        <p className="text-2xl mb-10">Quality components for every model.</p>
+        <a
+          href="#quote"
+          className="bg-purple-600 hover:bg-purple-500 text-white px-8 py-4 rounded"
+        >
+          Request Quote
+        </a>
+      </header>
+
+      <main className="space-y-20 px-6">
+        <section className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto" id="quote">
+          <div className="p-6 bg-white rounded shadow">
+            <h2 className="text-xl font-bold mb-2">Extensive Catalog</h2>
+            <p>Thousands of part numbers stocked and ready to ship.</p>
+          </div>
+          <div className="p-6 bg-white rounded shadow">
+            <h2 className="text-xl font-bold mb-2">Doorstep Delivery</h2>
+            <p>Rapid logistics to keep your shop moving.</p>
+          </div>
+          <div className="p-6 bg-white rounded shadow">
+            <h2 className="text-xl font-bold mb-2">Dedicated Support</h2>
+            <p>Our team helps you find exactly what you need.</p>
+          </div>
+        </section>
+
+        <section className="text-center">
+          <h2 className="text-4xl font-extrabold mb-4">Let's Talk</h2>
+          <p className="mb-6">Schedule a quick consultation and discover how we simplify sourcing.</p>
+          <a
+            href="mailto:sales@autolinkglobal.com"
+            className="bg-purple-600 hover:bg-purple-500 text-white px-8 py-4 rounded"
+          >
+            Email Sales
+          </a>
+        </section>
+      </main>
+
+      <footer className="py-10 text-center text-sm text-gray-600">
+        © 2025 AutoLink Global - Version 2
+      </footer>
+    </div>
+  )
+}
+
+export default LandingPageVersion2


### PR DESCRIPTION
## Summary
- implement two alternate landing pages with unique themes
- expose each version at `/version1` and `/version2`

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68599194cb7c83258baf954dc0d3e525