### PR TITLE
Add Tawk.to live chat to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,20 @@
   <body>
     <div id="root"></div>
     <script src="https://assets.calendly.com/assets/external/widget.js" async></script>
+    <!--Start of Tawk.to Script-->
+    <script type="text/javascript">
+      var Tawk_API = Tawk_API || {}, Tawk_LoadStart = new Date();
+      (function () {
+        var s1 = document.createElement("script"),
+          s0 = document.getElementsByTagName("script")[0];
+        s1.async = true;
+        s1.src = "https://embed.tawk.to/685aa6b5d9fc86190a69608d/1iuh1mdeh";
+        s1.charset = "UTF-8";
+        s1.setAttribute("crossorigin", "*");
+        s0.parentNode.insertBefore(s1, s0);
+      })();
+    </script>
+    <!--End of Tawk.to Script-->
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- embed Tawk.to script in `index.html` to enable live chat support

## Testing
- `pnpm run lint`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_685aa7df90508325921a54c4a9978e94